### PR TITLE
Fix : 공통파일 - 헤더 검색 CSS 적용 이슈 해결 (Issue #6)

### DIFF
--- a/shopeasy/src/index.css
+++ b/shopeasy/src/index.css
@@ -23,7 +23,6 @@ body {
 .input {
   color: beige;
   background-color: transparent;
-  margin-bottom: 30px;
 }
 
 .input::placeholder {

--- a/shopeasy/src/styles/Header.css
+++ b/shopeasy/src/styles/Header.css
@@ -8,6 +8,8 @@
   width: 150px;
 }
 
+
+/*홈바, 메뉴바 공통*/
 .header-bar ul {
   padding: 0; 
   margin: 0; 
@@ -20,12 +22,16 @@
   margin: 0 20px 0 20px;
 }
 
+
+/*홈바*/
 .homebar {
   color: #ffffff;
   font-size: 15px;
   font-weight: 600;
 }
 
+
+/*메뉴바*/
 #header-menubar-column {
   margin-top: 30px;
 }
@@ -45,6 +51,8 @@
   align-items: center;
 }
 
+
+/*장바구니*/
 #header-cart {
   margin: 20px 20px;
   display: flex;
@@ -68,9 +76,12 @@
   padding-top: 7px;
 }
 
+
+/*검색*/
 #header-search {
   margin: 0 15px;
   display: flex;
+  align-items: center;
 }
 
 #header-search input {
@@ -91,14 +102,17 @@ input:-ms-input-placeholder{
 
 #header-search-button {
   background-color: #db545a; /* 테두리 색상 설정 */
+  height: 35px;
 }
 
+
+/*반응형 웹 디자인*/
 @media (max-width: 767px) {
   #header-top {
     display: flex;
     align-items: center;
     flex-direction: column;
-    margin-bottom: 50px;
+    margin-bottom: 90px;
   }
   #header-menubar-column {
     visibility: show;


### PR DESCRIPTION
<!-- 풀 리퀘스트 제목 형식은 아래와 같이 한다. -->
<!-- Type: 키워드 - 이슈 제목 (Issue #None) -->
<!-- 반드시 .github 내부에 파일을 둘 것 -->

## 관련 이슈

* #6 

<br>

## 변경 사항
<!--코드 변경 이유까지 작성할 것-->
<!--관련 스크린샷이 있다면 첨부할 것-->

- index.css 파일에서 .input의 margin 제거했습니다.
- login.css 파일에서 개별적으로 margin 부여했습니다.

<br>

## 트러블 슈팅
<!-- 관련 스크린샷이 있다면 첨부할 것 -->  

### 이슈
feature/login 작성 중 공통 CSS 파일인 index.css에 .input에 margin을 주었고, margin이 없어야 하는 헤더 파일에서는 검색 input 란에 잘못된 CSS가 적용되는 이슈가 있었습니다.

### 해결
index.css 파일에서 .input의 margin을 없애고 추후 login.css 파일에 개별적으로 margin을 부여해주는 방법으로 해결했습니다.